### PR TITLE
allow a space between the double slash and gcassert:

### DIFF
--- a/gcassert.go
+++ b/gcassert.go
@@ -52,7 +52,7 @@ type lineInfo struct {
 	passedDirective map[int]bool
 }
 
-var gcAssertRegex = regexp.MustCompile(`//gcassert:([\w,]+)`)
+var gcAssertRegex = regexp.MustCompile(`// ?gcassert:([\w,]+)`)
 
 type assertVisitor struct {
 	commentMap ast.CommentMap


### PR DESCRIPTION
Previously, only the comments of the form `//gcassert:` would match the
regex pattern. This commit eases up the matching to also work for
`// gcassert:` (note the space after the double slash). We already have
a few cases like that in CockroachDB repo (even introduced by the author
of the gcassert himself :D ), so it makes sense to relax the matching
a bit.