### PR TITLE
[dnm] demonstrate that dead code hits assertions

### DIFF
--- a/gcassert_test.go
+++ b/gcassert_test.go
@@ -59,6 +59,7 @@ func TestParseDirectives(t *testing.T) {
 			52: {directives: []assertDirective{inline}},
 			56: {directives: []assertDirective{inline}},
 			59: {directives: []assertDirective{inline}},
+			61: {directives: []assertDirective{inline}},
 			63: {directives: []assertDirective{inline}},
 		},
 		"testdata/noescape.go": {
@@ -93,6 +94,7 @@ testdata/bce.go:19:	sum += notInlinable(ints[i]): call was not inlined
 testdata/inline.go:46:	alwaysInlined(3): call was not inlined
 testdata/inline.go:52:	sum += notInlinable(i): call was not inlined
 testdata/inline.go:56:	sum += 1: call was not inlined
+testdata/inline.go:61:	test(0).alwaysInlinedMethod(): call was not inlined
 testdata/inline.go:63:	test(0).neverInlinedMethod(10): call was not inlined
 testdata/inline.go:65:	otherpkg.A{}.NeverInlined(sum): call was not inlined
 `

--- a/gcassert_test.go
+++ b/gcassert_test.go
@@ -54,12 +54,12 @@ func TestParseDirectives(t *testing.T) {
 			19: {directives: []assertDirective{bce, inline}},
 		},
 		"testdata/inline.go": {
-			45: {directives: []assertDirective{inline}},
-			49: {directives: []assertDirective{inline}},
-			51: {directives: []assertDirective{inline}},
-			55: {directives: []assertDirective{inline}},
-			57: {directives: []assertDirective{inline}},
-			58: {directives: []assertDirective{inline}},
+			46: {directives: []assertDirective{inline}},
+			50: {directives: []assertDirective{inline}},
+			52: {directives: []assertDirective{inline}},
+			56: {directives: []assertDirective{inline}},
+			59: {directives: []assertDirective{inline}},
+			63: {directives: []assertDirective{inline}},
 		},
 		"testdata/noescape.go": {
 			21: {directives: []assertDirective{noescape}},
@@ -90,11 +90,11 @@ testdata/noescape.go:44:	: a escapes to heap:
 testdata/bce.go:8:	fmt.Println(ints[5]): Found IsInBounds
 testdata/bce.go:17:	sum += notInlinable(ints[i]): call was not inlined
 testdata/bce.go:19:	sum += notInlinable(ints[i]): call was not inlined
-testdata/inline.go:45:	alwaysInlined(3): call was not inlined
-testdata/inline.go:51:	sum += notInlinable(i): call was not inlined
-testdata/inline.go:55:	sum += 1: call was not inlined
-testdata/inline.go:58:	test(0).neverInlinedMethod(10): call was not inlined
-testdata/inline.go:60:	otherpkg.A{}.NeverInlined(sum): call was not inlined
+testdata/inline.go:46:	alwaysInlined(3): call was not inlined
+testdata/inline.go:52:	sum += notInlinable(i): call was not inlined
+testdata/inline.go:56:	sum += 1: call was not inlined
+testdata/inline.go:63:	test(0).neverInlinedMethod(10): call was not inlined
+testdata/inline.go:65:	otherpkg.A{}.NeverInlined(sum): call was not inlined
 `
 	assert.Equal(t, expectedOutput, w.String())
 }

--- a/testdata/inline.go
+++ b/testdata/inline.go
@@ -58,7 +58,7 @@ func caller() {
 	if bits.UintSize == 64 {
 		sum += test(0).alwaysInlinedMethod()
 	} else {
-		// placeholder
+		sum -= test(0).alwaysInlinedMethod()
 	}
 	sum += test(0).neverInlinedMethod(10)
 

--- a/testdata/inline.go
+++ b/testdata/inline.go
@@ -2,6 +2,7 @@ package gcassert
 
 import (
 	"fmt"
+	"math/bits"
 
 	"github.com/jordanlewis/gcassert/testdata/otherpkg"
 )
@@ -54,7 +55,11 @@ func caller() {
 	// This assertion should fail as there's nothing to inline.
 	sum += 1 //gcassert:inline
 
-	sum += test(0).alwaysInlinedMethod()
+	if bits.UintSize == 64 {
+		sum += test(0).alwaysInlinedMethod()
+	} else {
+		// placeholder
+	}
 	sum += test(0).neverInlinedMethod(10)
 
 	otherpkg.A{}.NeverInlined(sum)


### PR DESCRIPTION
In https://github.com/cockroachdb/apd/pull/103, I'm looking into hooking up gcassert to CI. It's pretty magical to be able to add these assertions in and protect against regressions in carefully tuned code. I'd like to start using it in more places.

Unfortunately, I'm running into the problem that platform-specific conditional logic that leads to compile-time dead code can cause assertion failures if one of these assertions lands in the dead code. I'm not quite sure what to do about that, so I figured I'd open up a PR to demonstrate the problem.