### PR TITLE
fix absolute path computation in `cwd` case

### DIFF
--- a/gcassert.go
+++ b/gcassert.go
@@ -224,11 +224,10 @@ func GCAssertCwd(w io.Writer, cwd string, paths ...string) error {
 			}
 			message := matches[4]
 
-			absPath, err := filepath.Abs(path)
-			if err != nil {
-				return err
+			if !filepath.IsAbs(path) {
+				path = filepath.Join(cwd, path)
 			}
-			if lineToDirectives := directiveMap[absPath]; lineToDirectives != nil {
+			if lineToDirectives := directiveMap[path]; lineToDirectives != nil {
 				info := lineToDirectives[lineNo]
 				if len(info.directives) > 0 {
 					if info.passedDirective == nil {

--- a/gcassert_test.go
+++ b/gcassert_test.go
@@ -127,11 +127,11 @@ testdata/issue5.go:4:	Gen().Layout(): call was not inlined
 		{
 			name: "relative-cwd",
 			pkgs: []string{
-				".",
-				"./otherpkg",
+				"./testdata",
+				"./testdata/otherpkg",
 			},
-			cwd: filepath.Join(cwd, "testdata"),
-			expected: strings.ReplaceAll(expectedOutput, "testdata/", ""),
+			cwd: cwd,
+			expected: expectedOutput,
 		},
 	}
 	for _, testCase := range testCases {


### PR DESCRIPTION
This was using `Abs()`, which is correct if we always run in the `cwd`, but not if a custom one was passed in.

See https://github.com/cockroachdb/cockroach/issues/121312