### PR TITLE
fix inline directive for a function only called from other packages

### DIFF
--- a/gcassert.go
+++ b/gcassert.go
@@ -390,10 +390,11 @@ func (v *inlinedDeclVisitor) Visit(node ast.Node) (w ast.Visitor) {
 			obj = v.p.TypesInfo.Uses[n]
 		case *ast.SelectorExpr:
 			sel := v.p.TypesInfo.Selections[n]
-			if sel == nil {
-				break
+			if sel != nil {
+				obj = sel.Obj()
+			} else {
+				obj = v.p.TypesInfo.Uses[n.Sel]
 			}
-			obj = sel.Obj()
 		}
 		if _, ok := v.mustInlineFuncs[obj]; ok {
 			lineInfo := v.directiveMap[lineNumber]

--- a/gcassert_test.go
+++ b/gcassert_test.go
@@ -99,13 +99,14 @@ testdata/inline.go:51:	sum += notInlinable(i): call was not inlined
 testdata/inline.go:55:	sum += 1: call was not inlined
 testdata/inline.go:58:	test(0).neverInlinedMethod(10): call was not inlined
 testdata/inline.go:60:	otherpkg.A{}.NeverInlined(sum): call was not inlined
+testdata/inline.go:62:	otherpkg.NeverInlinedFunc(sum): call was not inlined
 testdata/issue5.go:4:	Gen().Layout(): call was not inlined
 `
 
 	testCases := []struct{
-		name string
-		pkgs []string
-		cwd string
+		name     string
+		pkgs     []string
+		cwd      string
 		expected string
 	}{
 		{
@@ -130,7 +131,7 @@ testdata/issue5.go:4:	Gen().Layout(): call was not inlined
 				"./testdata",
 				"./testdata/otherpkg",
 			},
-			cwd: cwd,
+			cwd:      cwd,
 			expected: expectedOutput,
 		},
 	}

--- a/testdata/inline.go
+++ b/testdata/inline.go
@@ -58,4 +58,6 @@ func caller() {
 	sum += test(0).neverInlinedMethod(10)
 
 	otherpkg.A{}.NeverInlined(sum)
+
+	otherpkg.NeverInlinedFunc(sum)
 }

--- a/testdata/otherpkg/foo.go
+++ b/testdata/otherpkg/foo.go
@@ -10,3 +10,10 @@ func (a A) NeverInlined(n int) {
 		fmt.Println(i)
 	}
 }
+
+//gcassert:inline
+func NeverInlinedFunc(n int) {
+	for i := 0; i < n; i++ {
+		fmt.Println(i)
+	}
+}


### PR DESCRIPTION
When a top-level function is called from another packages, the
selector expression `pkg.FuncName` is not handled correctly.

This commit fixes this case by checking the Ident in the selector
expression.

Fixes #17