### PR TITLE
output error if a directive is invalid

### DIFF
--- a/testdata/bad_directive.go
+++ b/testdata/bad_directive.go
@@ -1,0 +1,14 @@
+package gcassert
+
+//gcassert:foo
+func badDirective1() {}
+
+func badDirective2() {
+	//gcassert:bce,bar,inline
+	badDirective1()
+}
+
+//gcassert:inline,afterinline
+func badDirective3() {
+	badDirective2()
+}

--- a/testdata/noescape.go
+++ b/testdata/noescape.go
@@ -1,13 +1,3 @@
-// Copyright 2021 The Cockroach Authors.
-//
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
-
 package gcassert
 
 type foo struct {
@@ -18,14 +8,14 @@ type foo struct {
 func returnsStackVarPtr() *foo {
 	// this should fail
 	//gcassert:noescape
-	foo := foo{a: 1, b:2}
+	foo := foo{a: 1, b: 2}
 	return &foo
 }
 
 func returnsStackVar() foo {
 	// this should succeed
 	//gcassert:noescape
-	foo := foo{a: 1, b:2}
+	foo := foo{a: 1, b: 2}
 	return foo
 }
 
@@ -33,17 +23,18 @@ func returnsStackVar() foo {
 //
 //gcassert:noescape
 func (f foo) setA(a int) *foo {
-    f.a = a
-    return &f
+	f.a = a
+	return &f
 }
 
 // This annotation should pass, because f does not escape.
+//
 //gcassert:noescape
 func (f foo) returnA(
-// This annotation should fail, because a will escape to the heap.
-//gcassert:noescape
-    a int,
-    b int,
+	// This annotation should fail, because a will escape to the heap.
+	//gcassert:noescape
+	a int,
+	b int,
 ) *int {
-    return &a
+	return &a
 }


### PR DESCRIPTION
Invalid directives are silently ignored; a simple typo can make us
think that the intended assertion passes.

This change outputs errors if any directives are invalid.